### PR TITLE
Fixed Warning in Vector DB

### DIFF
--- a/problem-solver/py/api/chroma_utils.py
+++ b/problem-solver/py/api/chroma_utils.py
@@ -1,13 +1,13 @@
 from langchain_community.document_loaders import PyPDFLoader, Docx2txtLoader, UnstructuredHTMLLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from langchain_community.embeddings.sentence_transformer import SentenceTransformerEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_chroma import Chroma
 from typing import List
 from langchain_core.documents import Document
 
 text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200, length_function=len)
 
-embedding_function = SentenceTransformerEmbeddings(model_name="all-MiniLM-L6-v2")
+embedding_function = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
 
 vectorstore = Chroma(persist_directory="./chroma_db", embedding_function=embedding_function)
 

--- a/problem-solver/py/requirements.txt
+++ b/problem-solver/py/requirements.txt
@@ -15,3 +15,4 @@ python-multipart
 sentence-transformers
 fastapi
 uvicorn
+langchain-huggingface 

--- a/problem-solver/py/requirements.txt
+++ b/problem-solver/py/requirements.txt
@@ -9,10 +9,10 @@ langchain
 langchain-core
 langchain_community
 langchain_chroma
+langchain-huggingface 
 docx2txt
 pypdf
 python-multipart
 sentence-transformers
 fastapi
 uvicorn
-langchain-huggingface 


### PR DESCRIPTION
After command `uvicorn main:app --reload` in problem-solver/py/api/chroma_utils, there was an error, that the HuggingFaceEmbeddings class from LangChain has been deprecated as of version 0.2.2 and will be removed in version 1.0. I removed previous import: `from langchain_community.embeddings.sentence_transformer import SentenceTransformerEmbeddings`. And added this import: `from langchain_huggingface import HuggingFaceEmbeddings`. Also changed class that initializes the sentence_transofrmer. 
Also there is updates in requirements.txt: new line langchain-huggingface. 